### PR TITLE
Add an example of log that returns something other than unit.

### DIFF
--- a/code/src/main/scala/introduction/01-basics.scala
+++ b/code/src/main/scala/introduction/01-basics.scala
@@ -63,6 +63,9 @@ object Basics extends IOApp.Simple {
   }
 
   // 5. Write a method that adds logging before and after an IO
+  // Here's an example of how to use it:
+  //
+  // log(IO.realTime).flatMap(time => IO.println(s"The time is $time"))
 
   // 6. What do the *> and <* methods do? Could you use them in the logging
   // method you just wrote?


### PR DESCRIPTION
The [log exercise](https://github.com/creativescala/cats-effect-tutorial/blob/main/code/src/main/scala/introduction/01-basics.scala#L65) is excellent for teaching `IO` program composition.

However, students end up with the function signature `log[A](io: IO[A]): IO[Unit]`.
They then can't see the difference between the `*>` and `<*` operators.

As an example, the following function body is "correct", but not what we want:

```scala
def log[A](io: IO[A]): IO[Unit] = 
  IO.println("Starting the IO") *> io *> IO.println("Ending the IO")
```

It might be better to nudge them towards an `IO[A]` return type:

```scala
def log[A](io: IO[A]): IO[A] = 
  IO.println("Starting the IO") *> io <* IO.println("Ending the IO")
```